### PR TITLE
Exclude fsaStoreKey and fsaStoreURL from environment checks

### DIFF
--- a/scripts/env-checks/env_validator.js
+++ b/scripts/env-checks/env_validator.js
@@ -35,6 +35,8 @@ const isCIEnvironment =
 const envCheckExclusions = [
   "ALGOLIA_MAX_RECORDS",
   "ANALYZE_BUNDLE",
+  "fsaStoreKey",
+  "fsaStoreURL",
   "GRAPHQL_SERVER_URL",
   "HEAD",
   "NEXT_PUBLIC_SENTRY_DSN",


### PR DESCRIPTION
This pull request updates the `env-validator.js` file to exclude the `fsaStoreKey` and `fsaStoreURL` from the environment checks. This change ensures that these variables are not included in the list of environment variables that are validated.