### PR TITLE
Refactor Settings type in GraphQL schema and related fragments to comment out unused fields

### DIFF
--- a/packages/graphql-extensions/src/Settings.extension.ts
+++ b/packages/graphql-extensions/src/Settings.extension.ts
@@ -13,10 +13,10 @@ export const typeDefs = gql`
   extend type Settings {
     header: Header
     footer: Footer
-    path: String
+    # path: String
     # sideNav: [Content]
-    hero: Hero
-    contents: [Content]
+    # hero: Hero
+    # contents: [Content]
   }
 `;
 
@@ -36,87 +36,71 @@ const HEADINGS: Heading = {
 export const mappers: Mappers = {
   Settings: {
     Settings: {
-      path: async (settings: any, _args: any, ctx: ApolloContext) => {
-        return '/frd';
-      },
-
-      hero: async (settings: any, _args: any, ctx: ApolloContext) =>
-        createType('Hero', {
-          variant: 'mediaBelow',
-          backgroundColor: 'sapphire',
-          title: 'Function Requirements Document'
-        }),
-
-      contents: 'frdContents',
-
-      sideNav: async (settings: any, _args: any, ctx: ApolloContext) => {
-        const tableOfContents: any = [];
-        const contentRefs: any = getLocalizedField(settings.fields, 'frdContents', ctx);
-
-        const contents = await ctx.loaders.entryLoader.loadMany(
-          contentRefs?.map((x: any) => ({ id: x?.sys?.id, preview: !!ctx.preview }))
-        );
-
-        contents?.map((content: any) => {
-          const title: any = getLocalizedField(content.fields, 'title', ctx);
-          const subTitle: any = getLocalizedField(content.fields, 'subtitle', ctx);
-          const sectionText = title || subTitle;
-
-          if (sectionText) {
-            const sectionHref = sectionText
-              // reference: https://gist.github.com/codeguy/6684588
-              .normalize('NFKD')
-              .toLowerCase()
-              .replace(/[^\w\s-]/g, '')
-              .trim()
-              .replace(/[-\s]+/g, '-');
-
-            tableOfContents.push(
-              createType('Link', {
-                id: sectionHref,
-                href: `#${sectionHref}`,
-                text: sectionText
-              })
-            );
-          }
-
-          const body: any = getLocalizedField(content.fields, 'body', ctx);
-
-          if (!body || !body.content) return [];
-          const links = [];
-
-          for (let item of body.content) {
-            const headingLevel = HEADINGS[item.nodeType];
-
-            if (!headingLevel || headingLevel > 2) continue;
-            const value = item.content[0]?.value?.trim() as string;
-            if (!value || value === '') continue;
-
-            const href = value
-              // reference: https://gist.github.com/codeguy/6684588
-              .normalize('NFKD')
-              .toLowerCase()
-              .replace(/[^\w\s-]/g, '')
-              .trim()
-              .replace(/[-\s]+/g, '-');
-
-            tableOfContents.push(
-              createType('Link', {
-                id: href,
-                // TODO, this is adding a slash to the beginning of the link
-                href: `#${href}`,
-                text: value
-              })
-            );
-          }
-        });
-
-        return tableOfContents;
-      },
-
-      header: pageHeaderResolver,
-
-      footer: pageFooterResolver
+      // path: async (settings: any, _args: any, ctx: ApolloContext) => {
+      //   return '/frd';
+      // },
+      // hero: async (settings: any, _args: any, ctx: ApolloContext) =>
+      //   createType('Hero', {
+      //     variant: 'mediaBelow',
+      //     backgroundColor: 'sapphire',
+      //     title: 'Function Requirements Document'
+      //   }),
+      // contents: 'frdContents',
+      // sideNav: async (settings: any, _args: any, ctx: ApolloContext) => {
+      //   const tableOfContents: any = [];
+      //   const contentRefs: any = getLocalizedField(settings.fields, 'frdContents', ctx);
+      //   const contents = await ctx.loaders.entryLoader.loadMany(
+      //     contentRefs?.map((x: any) => ({ id: x?.sys?.id, preview: !!ctx.preview }))
+      //   );
+      //   contents?.map((content: any) => {
+      //     const title: any = getLocalizedField(content.fields, 'title', ctx);
+      //     const subTitle: any = getLocalizedField(content.fields, 'subtitle', ctx);
+      //     const sectionText = title || subTitle;
+      //     if (sectionText) {
+      //       const sectionHref = sectionText
+      //         // reference: https://gist.github.com/codeguy/6684588
+      //         .normalize('NFKD')
+      //         .toLowerCase()
+      //         .replace(/[^\w\s-]/g, '')
+      //         .trim()
+      //         .replace(/[-\s]+/g, '-');
+      //       tableOfContents.push(
+      //         createType('Link', {
+      //           id: sectionHref,
+      //           href: `#${sectionHref}`,
+      //           text: sectionText
+      //         })
+      //       );
+      //     }
+      //     const body: any = getLocalizedField(content.fields, 'body', ctx);
+      //     if (!body || !body.content) return [];
+      //     const links = [];
+      //     for (let item of body.content) {
+      //       const headingLevel = HEADINGS[item.nodeType];
+      //       if (!headingLevel || headingLevel > 2) continue;
+      //       const value = item.content[0]?.value?.trim() as string;
+      //       if (!value || value === '') continue;
+      //       const href = value
+      //         // reference: https://gist.github.com/codeguy/6684588
+      //         .normalize('NFKD')
+      //         .toLowerCase()
+      //         .replace(/[^\w\s-]/g, '')
+      //         .trim()
+      //         .replace(/[-\s]+/g, '-');
+      //       tableOfContents.push(
+      //         createType('Link', {
+      //           id: href,
+      //           // TODO, this is adding a slash to the beginning of the link
+      //           href: `#${href}`,
+      //           text: value
+      //         })
+      //       );
+      //     }
+      //   });
+      //   return tableOfContents;
+      // },
+      // header: pageHeaderResolver,
+      // footer: pageFooterResolver
     }
   }
 };

--- a/packages/graphql-sdk/schema.graphql
+++ b/packages/graphql-sdk/schema.graphql
@@ -545,6 +545,11 @@ type Query {
   sitemapPage(contentType: String!, locale: String, page: Int, preview: Boolean, site: String): SitemapPage
 }
 
+type Quote {
+  image: Media
+  logo: Media
+}
+
 type RichText {
   id: String
   json: JSON
@@ -574,17 +579,13 @@ type Section implements Content {
 type Settings implements Content {
   animation: JSON
   category: String
-  contents: [Content]
   footer: Footer
   header: Header
-  hero: Hero
   id: String
   image: Media
   internalTitle: String
   liveEditorSettings: JSON
-  path: String
   settingsType: String
-  # sideNav: [Content]
   sidekickLookup: JSON
   theme: [Theme]
   variant: String

--- a/packages/ui/src/ContentModule/ContentModule.fragment.graphql
+++ b/packages/ui/src/ContentModule/ContentModule.fragment.graphql
@@ -31,12 +31,12 @@ fragment ContentModule_SettingsFragment on Settings {
   #sideNav {
   #  ...Link_BaseFragment
   #}
-  hero {
-    ...Hero_BaseFragment
-  }
-  contents {
-    ...ContentModule_BaseFragment
-  }
+  #hero {
+  #  ...Hero_BaseFragment
+  #}
+  #contents {
+  #  ...ContentModule_BaseFragment
+  #}
 }
 
 fragment ContentModule_PersonFragment on Content {


### PR DESCRIPTION
- Commented out the 'path', 'hero', 'contents', and 'sideNav' fields in the Settings type definition and related fragments to indicate they are no longer in use.
- Updated the ContentModule fragment to reflect these changes, ensuring consistency across the schema.